### PR TITLE
[ENH] Return full FD/DVARS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Release 0.8.5
 =============
 
+* [ENH] Provide full FD/DVARS files (https://github.com/poldracklab/mriqc/pull/128)
 * [ENH] Use MCFLIRT to compute motion parameters. AFNI's 3dvolreg now is optional (https://github.com/poldracklab/mriqc/pull/121)
 * [FIX] BIDS trees with anatomical images with different acquisition tokens (https://github.com/poldracklab/mriqc/pull/116)
 * [FIX] BIDS trees with anatomical images with several runs (https://github.com/poldracklab/mriqc/issues/112)

--- a/mriqc/__init__.py
+++ b/mriqc/__init__.py
@@ -32,7 +32,7 @@ Example
 """
 
 __versionbase__ = '0.8.5'
-__versionrev__ = 'a1'
+__versionrev__ = 'a2'
 __version__ = __versionbase__ + __versionrev__
 __author__ = 'Oscar Esteban'
 __email__ = 'code@oscaresteban.es'

--- a/mriqc/interfaces/qc.py
+++ b/mriqc/interfaces/qc.py
@@ -247,8 +247,8 @@ class FunctionalQC(BaseInterface):
                                     'p05': p05}
 
         # DVARS
-        self._results['dvars'] = float(np.mean(np.loadtxt(
-            self.inputs.in_dvars), axis=0)[0])
+        self._results['dvars'] = float(np.loadtxt(
+            self.inputs.in_dvars).mean())
 
         # tSNR
         tsnr_data = nb.load(self.inputs.in_tsnr).get_data()

--- a/mriqc/qc/functional.py
+++ b/mriqc/qc/functional.py
@@ -185,7 +185,7 @@ def dvars(in_file, in_mask, output_all=False, out_file=None):
         out_file = op.abspath(fname)
 
     np.savetxt(out_file, gendvars, fmt='%.12f')
-    return gendvars
+    return out_file
 
 
 def summary_fd(fd_movpar, fd_thres=1.0):

--- a/mriqc/qc/functional.py
+++ b/mriqc/qc/functional.py
@@ -18,8 +18,6 @@ Computation of the quality assessment measures on functional MRI
 import os.path as op
 import numpy as np
 import nibabel as nb
-from nitime import algorithms as nta
-import scipy
 
 
 def gsr(epi_data, mask, direction="y", ref_file=None, out_file=None):
@@ -104,7 +102,7 @@ def gsr(epi_data, mask, direction="y", ref_file=None, out_file=None):
     return float(ghost/signal)
 
 
-def dvars(func, mask, output_all=False, out_file=None):
+def dvars(in_file, in_mask, output_all=False, out_file=None):
     """
     Compute the mean :abbr:`DVARS (D referring to temporal
     derivative of timecourses, VARS referring to RMS variance over voxels)`
@@ -129,6 +127,14 @@ def dvars(func, mask, output_all=False, out_file=None):
     :return: the standardized DVARS
 
     """
+    import os.path as op
+    import numpy as np
+    import nibabel as nb
+    from nitime.algorithms import AR_est_YW
+
+    func = nb.load(in_file).get_data()
+    mask = nb.load(in_mask).get_data()
+
     if len(func.shape) != 4:
         raise RuntimeError(
             "Input fMRI dataset should be 4-dimensional" % func)
@@ -146,7 +152,7 @@ def dvars(func, mask, output_all=False, out_file=None):
     mfunc -= mfunc.mean(axis=1)[..., np.newaxis]
 
     # AR1
-    ak_coeffs = np.apply_along_axis(nta.AR_est_YW, 1, mfunc, 1)
+    ak_coeffs = np.apply_along_axis(AR_est_YW, 1, mfunc, 1)
 
     # Predicted standard deviation of temporal derivative
     func_sd_pd = np.squeeze(np.sqrt((2 * (1 - ak_coeffs[:, 0])).tolist()) * func_sd)
@@ -170,11 +176,30 @@ def dvars(func, mask, output_all=False, out_file=None):
     else:
         gendvars = dvars_stdz.reshape(len(dvars_stdz), 1)
 
-    if out_file is not None:
-        np.savetxt(out_file, gendvars, fmt='%.12f')
+    if out_file is None:
+        fname, ext = op.splitext(op.basename(in_file))
+        if ext == '.gz':
+            fname, _ = op.splitext(fname)
+        fname += '_dvars.txt'
+        out_file = op.abspath(fname)
 
+    np.savetxt(out_file, gendvars, fmt='%.12f')
     return gendvars
 
+
+def summary_fd(fd_movpar, fd_thres=1.0):
+    """
+    Generates a dictionary with the mean FD, the number of FD timepoints above
+    fd_thres, and the percentage of FD timepoints above the fd_thres
+    """
+    fddata = np.loadtxt(fd_movpar)
+    num_fd = np.float((fddata > fd_thres).sum())
+    out_dict = {
+        'mean_fd': float(fddata.mean()),
+        'num_fd': int(num_fd),
+        'perc_fd': float(num_fd * 100 / (len(fddata) + 1))
+    }
+    return out_dict
 
 def gcor(func, mask):
     """
@@ -185,10 +210,11 @@ def gcor(func, mask):
     :return: the computed GCOR value
 
     """
+    from scipy.stats.mstats import zscore
     # Remove zero-variance voxels across time axis
     tv_mask = zero_variance(func, mask)
     idx = np.where(tv_mask > 0)
-    zscores = scipy.stats.mstats.zscore(func[idx[0], idx[1], idx[2], :], axis=1)
+    zscores = zscore(func[idx[0], idx[1], idx[2], :], axis=1)
     avg_ts = zscores.mean(axis=0)
     return float(avg_ts.transpose().dot(avg_ts) / len(avg_ts))
 

--- a/mriqc/qc/functional.py
+++ b/mriqc/qc/functional.py
@@ -131,6 +131,7 @@ def dvars(in_file, in_mask, output_all=False, out_file=None):
     import numpy as np
     import nibabel as nb
     from nitime.algorithms import AR_est_YW
+    from mriqc.qc.functional import zero_variance
 
     func = nb.load(in_file).get_data()
     mask = nb.load(in_mask).get_data()


### PR DESCRIPTION
This commit fixes #127 and closes #125.

Now, full FD and DVARS are available in the outputnode of the functional workflow.