### PR TITLE
[FIX] More reliable group-reports stage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,17 @@
+Release 0.8.8
+=============
+
+* [FIX] More reliable group level (#238)
+* [ENH] Add --verbose-reports for fMRI (#236)
+* [ENH] Migrate functional reports to html (#232)
+* [ENH] Add 0.2 FD cutoff line (#231)
+* [ENH] Add AFNI's outlier count to carpet plot confound charts (#230) 
+
 Release 0.8.7
 =============
 
-* [ENH] Add kurtosis to summary statistics
+* [ENH] Anatomical Group reports in html (#227)
+* [ENH] Add kurtosis to summary statistics (#224)
 * [ENH] New report layout for fMRI, added carpetplot (#198)
 * [ENH] Anatomical workflow refactor (#219).
 

--- a/docker/Dockerfile_py27
+++ b/docker/Dockerfile_py27
@@ -41,7 +41,7 @@ ENV PATH /usr/local/miniconda/bin:$PATH
 
 # Create conda environment
 RUN conda config --add channels conda-forge && \
-    conda install -y numpy scipy lockfile matplotlib && \
+    conda install -y numpy scipy matplotlib && \
     pip install -e git+https://github.com/nipy/nipype.git@master#egg=nipype && \
     python -c "from matplotlib import font_manager"
 

--- a/docker/Dockerfile_py35
+++ b/docker/Dockerfile_py35
@@ -46,9 +46,8 @@ WORKDIR /root
 
 # Create conda environment, use nipype's conda-forge channel
 RUN conda config --add channels conda-forge && \
-    conda install -y numpy scipy lockfile matplotlib && \
+    conda install -y numpy scipy matplotlib && \
     pip install -e git+https://github.com/nipy/nipype.git@master#egg=nipype && \
-    pip install -e git+https://github.com/oesteban/rst2pdf.git@futurize/stage2#egg=rst2pdf && \
     python -c "from matplotlib import font_manager"
 
 # Install mriqc

--- a/mriqc/utils/mriqc_run.py
+++ b/mriqc/utils/mriqc_run.py
@@ -3,7 +3,7 @@
 # @Author: oesteban
 # @Date:   2015-11-19 16:44:27
 # @Last Modified by:   oesteban
-# @Last Modified time: 2016-11-03 13:21:22
+# @Last Modified time: 2016-11-03 13:38:45
 
 """
 =====
@@ -17,9 +17,7 @@ from __future__ import unicode_literals
 
 import os
 import os.path as op
-from errno import EEXIST
 from multiprocessing import cpu_count
-from lockfile import LockFile
 
 from argparse import ArgumentParser
 from argparse import RawTextHelpFormatter
@@ -145,11 +143,10 @@ def main():
     if not settings['report_dir']:
         settings['report_dir'] = op.join(settings['work_dir'], 'reports')
 
-    with LockFile(op.join(os.getenv('HOME'), '.mriqc-lock')):
-        check_folder(settings['output_dir'])
-        check_folder(settings['work_dir'])
-        check_folder(log_dir)
-        check_folder(settings['report_dir'])
+    check_folder(settings['output_dir'])
+    check_folder(settings['work_dir'])
+    check_folder(log_dir)
+    check_folder(settings['report_dir'])
 
     # Set nipype config
     ncfg.update_config({
@@ -202,15 +199,16 @@ def main():
 
         derivatives_dir = op.join(settings['output_dir'], 'derivatives')
         for qctype in opts.data_type:
-
             qcjson = op.join(derivatives_dir, '{}*.json'.format(qctype[:4]))
 
+            # If there are no iqm.json files, nothing to do.
             if not qcjson:
                 MRIQC_LOG.warn(
                     'Generating group-level report for the "%s" data type - '
                     'no IQM-JSON files were found in "%s"', qctype, derivatives_dir)
                 continue
 
+            # If some were found, generate the CSV file and group report
             out_csv = op.join(settings['output_dir'], qctype[:4] + 'MRIQC.csv')
             out_html = op.join(reports_dir, qctype[:4] + '_group.html')
             generate_csv(glob(qcjson), out_csv)


### PR DESCRIPTION
This PR wants to fix two problems:

  1. The group level failed when no anatomical qc-json files were
     found in the derivatives folder. Now, it will only issue a warning

  2. The group level will automatically be executed if no --participant_label
     was specified.

Closes #196