### PR TITLE
[ENH] Deprecate --nthreads flag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,10 +33,10 @@ test:
     # Test mriqcp
     - docker run -i -v /etc/localtime:/etc/localtime:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v ${CIRCLE_TEST_REPORTS}:/scratch -w /root/src/mriqc --entrypoint="/usr/bin/run_tests" mriqc:py35 :
         timeout: 2600
-    - docker run -i -v /etc/localtime:/etc/localtime:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v ~/data:/data:ro -v $SCRATCH/func:/scratch -w /scratch mriqc:py35 /data/ds003_downsampled out/ participant -d func -w work/ --nthreads ${FUNC_NPROCS} --testing :
+    - docker run -i -v /etc/localtime:/etc/localtime:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v ~/data:/data:ro -v $SCRATCH/func:/scratch -w /scratch mriqc:py35 /data/ds003_downsampled out/ participant -d func -w work/ --n_procs ${FUNC_NPROCS} --testing :
         timeout: 2600
     - docker run -i -v /etc/localtime:/etc/localtime:ro -v ~/data:/data:ro -v $SCRATCH/func:/scratch -w /scratch mriqc:py35 /data/ds003_downsampled out/ group -d func -w work/
-    - docker run -i -v /etc/localtime:/etc/localtime:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v ~/data:/data:ro -v $SCRATCH/anat:/scratch -w /scratch mriqc:py35 /data/ds003_downsampled out/ participant -d anat -w work/ --nthreads ${ANAT_NPROCS} --testing --ants-nthreads ${ANTS_NTHREADS} --verbose-reports :
+    - docker run -i -v /etc/localtime:/etc/localtime:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v ~/data:/data:ro -v $SCRATCH/anat:/scratch -w /scratch mriqc:py35 /data/ds003_downsampled out/ participant -d anat -w work/ --n_procs ${ANAT_NPROCS} --testing --ants-nthreads ${ANTS_NTHREADS} --verbose-reports :
         timeout: 2600
     - docker run -i -v /etc/localtime:/etc/localtime:ro -v ~/data:/data:ro -v $SCRATCH/anat:/scratch -w /scratch mriqc:py27 /data/ds003_downsampled out/ group -d anat -w work/
 


### PR DESCRIPTION
Use ```--n_procs``` as of now. ```--nthreads``` will still work for a while.