### PR TITLE
[FIX] MRIQC crashed generating csv files  …

### DIFF
--- a/mriqc/reports/group.py
+++ b/mriqc/reports/group.py
@@ -89,7 +89,7 @@ def gen_html(csv_file, qctype, out_file=None):
     nPart = len(dataframe)
 
     csv_groups = []
-    for group, units in QCGROUPS[qctype]:
+    for group, units in QCGROUPS[qctype[:4]]:
         dfdict = {'iqm': [], 'value': [], 'label': [], 'units': []}
 
         for iqm in group:
@@ -124,6 +124,4 @@ def gen_html(csv_file, qctype, out_file=None):
             remove(dstpath)
 
         copy(pkgrf('mriqc', op.join('data', 'reports', 'resources', fname)), dstpath)
-
-    MRIQC_REPORT_LOG.info('Generated group-level report (%s)', out_file)
     return out_file

--- a/mriqc/utils/misc.py
+++ b/mriqc/utils/misc.py
@@ -363,7 +363,7 @@ def generate_csv(jsonfiles, out_fname):
     errorlist = []
 
     if not jsonfiles:
-        raise RuntimeError('No QC-json files found to generate QC table')
+        return None
 
     for jsonfile in jsonfiles:
         dfentry = _read_and_save(jsonfile)


### PR DESCRIPTION
when the json files for a modality was missing.
This caused that, in datasets with only (for example) anatomical images,
the group level report always failed when trying to generate the
functional group-report.

Now, MRIQC will only issue a warning when there are no measure files
for a modality.

Fixes #282