### PR TITLE
[ENH] A functional implementation of registration with ANTS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 Release 0.8.8
 =============
 
-* [ENH] Replace BBR by ANTs (#295)
+* [ENH] Replace BBR by ANTs (#295, #296)
 * [FIX] Singularity: user-environment leaking into container (#293)
 * [ENH] Report failed cases in group report (#291)
 * [FIX] Brighter anatomical --verbose-reports (#290)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Release 0.8.8
 =============
 
+* [ENH] Replace BBR by ANTs (#295)
 * [FIX] Singularity: user-environment leaking into container (#293)
 * [ENH] Report failed cases in group report (#291)
 * [FIX] Brighter anatomical --verbose-reports (#290)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ numpy
 future
 matplotlib
 nibabel
-niworkflows>=0.0.3a19
+niworkflows>=0.0.3a20
 pandas
 dipy
 jinja2

--- a/mriqc/info.py
+++ b/mriqc/info.py
@@ -8,7 +8,7 @@ MRIQC
 """
 
 __versionbase__ = '0.8.8'
-__versionrev__ = 'rc14'
+__versionrev__ = 'rc15'
 __version__ = __versionbase__ + __versionrev__
 __author__ = 'Oscar Esteban'
 __email__ = 'code@oscaresteban.es'
@@ -50,7 +50,7 @@ REQUIRES = [
     'six',
     'matplotlib',
     'nibabel',
-    'niworkflows>=0.0.3a19',
+    'niworkflows>=0.0.3a20',
     'pandas',
     'dipy',
     'jinja2',

--- a/mriqc/interfaces/viz.py
+++ b/mriqc/interfaces/viz.py
@@ -197,9 +197,10 @@ class PlotSpikes(PlotBase):
         plot_mosaic_helper(
             op.abspath('spikes.nii.gz'),
             self.inputs.subject_id,
-            self.inputs.session_id,
-            self.inputs.run_id,
-            out_file,
+            session_id=self.inputs.session_id,
+            task_id=self.inputs.task_id,
+            run_id=self.inputs.run_id,
+            out_file=out_file,
             title=self._get_title(),
             cmap=self.inputs.cmap,
             plot_sagittal=False,

--- a/mriqc/interfaces/viz_utils.py
+++ b/mriqc/interfaces/viz_utils.py
@@ -510,6 +510,13 @@ def plot_mosaic_helper(in_file, subject_id, session_id=None,
                                 "run_id": run_id})
     fig = plot_mosaic(in_file, bbox_mask_file=bbox_mask_file, title=title, labels=labels,
                       only_plot_noise=only_plot_noise, cmap=cmap, plot_sagittal=plot_sagittal)
+
+    if out_file is None:
+        fname, ext = op.splitext(op.basename(in_file))
+        if ext == ".gz":
+            fname, _ = op.splitext(fname)
+        out_file = op.abspath(fname + '_mosaic.svg')
+
     fig.savefig(out_file, format=out_file.split('.')[-1], dpi=300)
     fig.clf()
     fig = None

--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -610,44 +610,6 @@ def epi_mni_align(name='SpatialNormalization', ants_nthreads=6, testing=False, r
     return workflow
 
 
-
-    # # Extract wm mask from segmentation
-    # wm_mask = pe.Node(niu.Function(input_names=['in_file'], output_names=['out_file'],
-    #                                function=thresh_image), name='WM_mask')
-    # wm_mask.inputs.in_file = op.join(mni_template, '1mm_tpm_wm.nii.gz')
-
-    # flt_bbr_init = pe.Node(fsl.FLIRT(dof=6, out_matrix_file='init.mat'),
-    #                        name='Flirt_BBR_init')
-    # flt_bbr = pe.Node(fsl.FLIRT(dof=12, cost_func='bbr'), name='Flirt_BBR')
-    # flt_bbr.inputs.schedule = op.join(os.getenv('FSLDIR'),
-    #                                   'etc/flirtsch/bbr.sch')
-
-    # # make equivalent warp fields
-    # invt_bbr = pe.Node(fsl.ConvertXFM(invert_xfm=True), name='Flirt_BBR_Inv')
-    # # Warp segmentation into EPI space
-    # segm_xfm = pe.Node(fsl.ApplyXfm(
-    #     in_file=op.join(mni_template, '1mm_parc.nii.gz'),
-    #     interp='nearestneighbour'), name='ResampleSegmentation')
-
-    # workflow.connect([
-    #     (inputnode, epimask, [('epi_mean', 'in_file'),
-    #                           ('epi_mask', 'mask_file')]),
-    #     (epimask, flt_bbr_init, [('out_file', 'in_file')]),
-    #     (epimask, flt_bbr, [('out_file', 'in_file')]),
-    #     (brainmask, flt_bbr_init, [('out_file', 'reference')]),
-    #     (brainmask, flt_bbr, [('out_file', 'reference')]),
-    #     (wm_mask, flt_bbr, [('out_file', 'wm_seg')]),
-    #     (flt_bbr_init, flt_bbr, [('out_matrix_file', 'in_matrix_file')]),
-    #     (flt_bbr, invt_bbr, [('out_matrix_file', 'in_file')]),
-    #     (invt_bbr, segm_xfm, [('out_file', 'in_matrix_file')]),
-    #     (inputnode, segm_xfm, [('epi_mean', 'reference')]),
-    #     (segm_xfm, outputnode, [('out_file', 'epi_parc')]),
-    #     (flt_bbr, outputnode, [('out_file', 'epi_mni')]),
-
-    # ])
-    # return workflow
-
-
 def spikes_mask(in_file, in_mask=None, out_file=None):
     import os.path as op
     import nibabel as nb

--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -551,7 +551,7 @@ def hmc_afni(name='fMRI_HMC_afni', st_correct=False, despike=False, deoblique=Fa
 
     return workflow
 
-def epi_mni_align(name='SpatialNormalization', ants_nthreads=6, testing=False):
+def epi_mni_align(name='SpatialNormalization', ants_nthreads=6, testing=False, resolution=2):
     """
     Uses FSL FLIRT with the BBR cost function to find the transform that
     maps the EPI space into the MNI152-nonlinear-symmetric atlas.
@@ -562,7 +562,7 @@ def epi_mni_align(name='SpatialNormalization', ants_nthreads=6, testing=False):
     the associated "lobe" parcellation in EPI space.
 
     """
-    from nipype.interfaces.ants import ApplyTransforms
+    from nipype.interfaces.ants import ApplyTransforms, N4BiasFieldCorrection
     from niworkflows.data import get_mni_icbm152_nlin_asym_09c as get_template
     from niworkflows.anat.mni import RobustMNINormalization
     mni_template = get_template()
@@ -575,78 +575,77 @@ def epi_mni_align(name='SpatialNormalization', ants_nthreads=6, testing=False):
 
     epimask = pe.Node(fsl.ApplyMask(), name='EPIApplyMask')
 
-    # Mask PD template image
+    n4itk = pe.Node(N4BiasFieldCorrection(dimension=3), name='SharpenEPI')
+    # Mask T2 template image
     brainmask = pe.Node(fsl.ApplyMask(
-        in_file=op.join(mni_template, '1mm_PD.nii.gz'),
-        mask_file=op.join(mni_template, '1mm_brainmask.nii.gz')),
+        in_file=op.join(mni_template, '%dmm_T2.nii.gz' % resolution),
+        mask_file=op.join(mni_template, '%dmm_brainmask.nii.gz' % resolution)),
         name='MNIApplyMask')
 
-    if testing:
-        resolution = 2
-        norm = pe.Node(RobustMNINormalization(
-            num_threads=ants_nthreads, template='mni_icbm152_nlin_asym_09c',
-            testing=testing, reference='T2', moving='EPI',
-            template_resolution=resolution),
-                       name='EPI2MNI')
+    norm = pe.Node(RobustMNINormalization(
+        num_threads=ants_nthreads, template='mni_icbm152_nlin_asym_09c',
+        testing=testing, moving='EPI'),
+                   name='EPI2MNI')
 
-        # Warp segmentation into EPI space
-        invt = pe.Node(ApplyTransforms(
-            input_image=op.join(mni_template, '%dmm_parc.nii.gz' % resolution),
-            dimension=3, default_value=0, interpolation='NearestNeighbor'),
-                       name='ResampleSegmentation')
-
-        workflow.connect([
-            (inputnode, invt, [('epi_mean', 'reference_image')]),
-            (inputnode, epimask, [('epi_mean', 'in_file'),
-                                  ('epi_mask', 'mask_file')]),
-            (brainmask, norm, [('out_file', 'reference_image')]),
-            (epimask, norm, [('out_file', 'moving_image')]),
-            (norm, invt, [
-                ('reverse_transforms', 'transforms'),
-                ('reverse_invert_flags', 'invert_transform_flags')]),
-            (invt, outputnode, [('output_image', 'epi_parc')]),
-            (norm, outputnode, [('warped_image', 'epi_mni')]),
-
-        ])
-        return workflow
-
-
-
-    # Extract wm mask from segmentation
-    wm_mask = pe.Node(niu.Function(input_names=['in_file'], output_names=['out_file'],
-                                   function=thresh_image), name='WM_mask')
-    wm_mask.inputs.in_file = op.join(mni_template, '1mm_tpm_wm.nii.gz')
-
-    flt_bbr_init = pe.Node(fsl.FLIRT(dof=6, out_matrix_file='init.mat'),
-                           name='Flirt_BBR_init')
-    flt_bbr = pe.Node(fsl.FLIRT(dof=12, cost_func='bbr'), name='Flirt_BBR')
-    flt_bbr.inputs.schedule = op.join(os.getenv('FSLDIR'),
-                                      'etc/flirtsch/bbr.sch')
-
-    # make equivalent warp fields
-    invt_bbr = pe.Node(fsl.ConvertXFM(invert_xfm=True), name='Flirt_BBR_Inv')
     # Warp segmentation into EPI space
-    segm_xfm = pe.Node(fsl.ApplyXfm(
-        in_file=op.join(mni_template, '1mm_parc.nii.gz'),
-        interp='nearestneighbour'), name='ResampleSegmentation')
+    invt = pe.Node(ApplyTransforms(
+        input_image=op.join(mni_template, '%dmm_parc.nii.gz' % resolution),
+        dimension=3, default_value=0, interpolation='NearestNeighbor'),
+                   name='ResampleSegmentation')
 
     workflow.connect([
-        (inputnode, epimask, [('epi_mean', 'in_file'),
-                              ('epi_mask', 'mask_file')]),
-        (epimask, flt_bbr_init, [('out_file', 'in_file')]),
-        (epimask, flt_bbr, [('out_file', 'in_file')]),
-        (brainmask, flt_bbr_init, [('out_file', 'reference')]),
-        (brainmask, flt_bbr, [('out_file', 'reference')]),
-        (wm_mask, flt_bbr, [('out_file', 'wm_seg')]),
-        (flt_bbr_init, flt_bbr, [('out_matrix_file', 'in_matrix_file')]),
-        (flt_bbr, invt_bbr, [('out_matrix_file', 'in_file')]),
-        (invt_bbr, segm_xfm, [('out_file', 'in_matrix_file')]),
-        (inputnode, segm_xfm, [('epi_mean', 'reference')]),
-        (segm_xfm, outputnode, [('out_file', 'epi_parc')]),
-        (flt_bbr, outputnode, [('out_file', 'epi_mni')]),
+        (inputnode, invt, [('epi_mean', 'reference_image')]),
+        (inputnode, n4itk, [('epi_mean', 'input_image')]),
+        (inputnode, epimask, [('epi_mask', 'mask_file')]),
+        (n4itk, epimask, [('output_image', 'in_file')]),
+        (brainmask, norm, [('out_file', 'reference_image')]),
+        (epimask, norm, [('out_file', 'moving_image')]),
+        (norm, invt, [
+            ('reverse_transforms', 'transforms'),
+            ('reverse_invert_flags', 'invert_transform_flags')]),
+        (invt, outputnode, [('output_image', 'epi_parc')]),
+        (norm, outputnode, [('warped_image', 'epi_mni')]),
 
     ])
     return workflow
+
+
+
+    # # Extract wm mask from segmentation
+    # wm_mask = pe.Node(niu.Function(input_names=['in_file'], output_names=['out_file'],
+    #                                function=thresh_image), name='WM_mask')
+    # wm_mask.inputs.in_file = op.join(mni_template, '1mm_tpm_wm.nii.gz')
+
+    # flt_bbr_init = pe.Node(fsl.FLIRT(dof=6, out_matrix_file='init.mat'),
+    #                        name='Flirt_BBR_init')
+    # flt_bbr = pe.Node(fsl.FLIRT(dof=12, cost_func='bbr'), name='Flirt_BBR')
+    # flt_bbr.inputs.schedule = op.join(os.getenv('FSLDIR'),
+    #                                   'etc/flirtsch/bbr.sch')
+
+    # # make equivalent warp fields
+    # invt_bbr = pe.Node(fsl.ConvertXFM(invert_xfm=True), name='Flirt_BBR_Inv')
+    # # Warp segmentation into EPI space
+    # segm_xfm = pe.Node(fsl.ApplyXfm(
+    #     in_file=op.join(mni_template, '1mm_parc.nii.gz'),
+    #     interp='nearestneighbour'), name='ResampleSegmentation')
+
+    # workflow.connect([
+    #     (inputnode, epimask, [('epi_mean', 'in_file'),
+    #                           ('epi_mask', 'mask_file')]),
+    #     (epimask, flt_bbr_init, [('out_file', 'in_file')]),
+    #     (epimask, flt_bbr, [('out_file', 'in_file')]),
+    #     (brainmask, flt_bbr_init, [('out_file', 'reference')]),
+    #     (brainmask, flt_bbr, [('out_file', 'reference')]),
+    #     (wm_mask, flt_bbr, [('out_file', 'wm_seg')]),
+    #     (flt_bbr_init, flt_bbr, [('out_matrix_file', 'in_matrix_file')]),
+    #     (flt_bbr, invt_bbr, [('out_matrix_file', 'in_file')]),
+    #     (invt_bbr, segm_xfm, [('out_file', 'in_matrix_file')]),
+    #     (inputnode, segm_xfm, [('epi_mean', 'reference')]),
+    #     (segm_xfm, outputnode, [('out_file', 'epi_parc')]),
+    #     (flt_bbr, outputnode, [('out_file', 'epi_mni')]),
+
+    # ])
+    # return workflow
 
 
 def spikes_mask(in_file, in_mask=None, out_file=None):


### PR DESCRIPTION
Now, the EPI2MNI replacement using ANTs instead of BBR works OK. Tested on the datasets of the bootcamp.

This also fixes a bug that happened when plotting the mosaic of spikes.