### PR TITLE
Insert version requirement for niworkflows

### DIFF
--- a/mriqc/info.py
+++ b/mriqc/info.py
@@ -50,7 +50,7 @@ REQUIRES = [
     'six',
     'matplotlib',
     'nibabel',
-    'niworkflows',
+    'niworkflows>=0.0.4a0',
     'pandas',
     'dipy',
     'jinja2',


### PR DESCRIPTION
Updated to 0.0.4, this should fix #329 after releasing to Pypi.