### PR TITLE
[RTM] Install mriqc in site-packages (disable editable mode)

### DIFF
--- a/docker/Dockerfile_py27
+++ b/docker/Dockerfile_py27
@@ -60,7 +60,7 @@ RUN npm install -g svgo
 WORKDIR /opt/src/mriqc
 COPY . /opt/src/mriqc/
 RUN pip install -r requirements.txt && \
-    pip install -e .[all]
+    pip install .[all]
 
 RUN mkdir /niworkflows_data
 ENV CRN_SHARED_DATA /niworkflows_data

--- a/docker/Dockerfile_py35
+++ b/docker/Dockerfile_py35
@@ -64,7 +64,7 @@ RUN pip install -r /opt/src/mriqc/requirements.txt
 
 WORKDIR /opt/src/mriqc
 
-RUN pip install -e .[all]
+RUN pip install .[all]
 
 RUN mkdir /niworkflows_data
 ENV CRN_SHARED_DATA /niworkflows_data


### PR DESCRIPTION
Makes it consistent with other dependencies and FMRIPREP and allows for injecting code when using Singularity.