### PR TITLE
[TST] Downgrade docker to 1.9.1 in circle (build_only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ ARG VCS_REF
 ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="MRIQC" \
-      org.label-schema.description="MRIQC  - NR-IQMs (no-reference Image Quality Metrics) for MRI" \
+      org.label-schema.description="MRIQC - Automated Quality Control and visual reports for Quality Assesment of structural (T1w, T2w) and functional MRI of the brain" \
       org.label-schema.url="http://mriqc.readthedocs.io" \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/poldracklab/mriqc" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,7 @@ RUN cd /root/src/mriqc && pip install .[classifier,duecredit] && \
 
 ENTRYPOINT ["/usr/local/miniconda/bin/mriqc"]
 
+# Store metadata
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION

--- a/circle.yml
+++ b/circle.yml
@@ -24,11 +24,13 @@ dependencies:
     - docker load --input $HOME/docker/cache.tar || true
   override:
     - docker pull poldracklab/mriqc:circleci || true
-    - |
-      e=1
-      for i in {1..5}; do
-          docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
-      done && [ "$e" -eq "0" ]
+    - ? |
+        e=1
+        for i in {1..5}; do
+            docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
+        done && [ "$e" -eq "0" ]
+      :
+        timeout: 3200
     - docker save -o $HOME/docker/cache.tar ubuntu:xenial-20161213 poldracklab/mriqc:circleci :
         timeout: 3200
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,4 @@
 machine:
-  pre:
-    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   environment:
     SCRATCH: "$HOME/scratch"
     TEST_DATA_NAME: "circle-tests"
@@ -25,7 +23,7 @@ dependencies:
     - |
       e=1
       for i in {1..5}; do
-          docker build --cache-from poldracklab/mriqc:circleci --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
+          docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
       done && [ "$e" -eq "0" ]
   post:
     - ? |

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ dependencies:
     - |
       e=1
       for i in {1..5}; do
-          docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
+          docker build --cache-from poldracklab/mriqc:circleci --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
       done && [ "$e" -eq "0" ]
   post:
     - ? |

--- a/circle.yml
+++ b/circle.yml
@@ -21,13 +21,18 @@ dependencies:
     - if [[ ! -d ~/data/${TEST_DATA_NAME} ]]; then wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q -O ${TEST_DATA_NAME}.tar.gz "${TEST_DATA_URL}" && tar xzf ${TEST_DATA_NAME}.tar.gz -C ~/data/; fi
   override:
     - sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" mriqc/info.py
-    - docker pull poldracklab/mriqc:latest || true
-    - e=1 && for i in {1..5}; do docker build --rm=false -t poldracklab/mriqc:latest --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15; done && [ "$e" -eq "0" ]
-
+    - docker pull poldracklab/mriqc:circleci || true
+    - e=1 && for i in {1..5}; do docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15; done && [ "$e" -eq "0" ]
+  post:
+    - if [[ -n "$DOCKER_PASS" ]]; then docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS && docker push poldracklab/mriqc:circleci; fi :
+        timeout: 21600
 test:
   override:
-    # Test mriqcp
-    - if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then docker run -i -v /etc/localtime:/etc/localtime:ro -v ${CIRCLE_TEST_REPORTS}:/scratch --entrypoint="py.test"  poldracklab/mriqc:latest --ignore=src/ --junitxml=/scratch/tests.xml /root/src/mriqc; fi :
+    - ? |
+        if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then
+            docker run -i -v /etc/localtime:/etc/localtime:ro -v ${CIRCLE_TEST_REPORTS}:/scratch --entrypoint="py.test"  poldracklab/mriqc:latest --ignore=src/ --junitxml=/scratch/tests.xml /root/src/mriqc;
+        fi
+      :
         timeout: 2600
         environment:
           GIT_COMMIT_MSG: $( git log --format=oneline -n 1 $CIRCLE_SHA1 )
@@ -50,6 +55,11 @@ test:
     - if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then docker run -i -v /etc/localtime:/etc/localtime:ro -v $SCRATCH:/scratch -w /scratch --entrypoint="dfcheck" poldracklab/mriqc:latest -i /scratch/out/bold.csv -r /root/src/mriqc/mriqc/data/testdata/bold.csv; fi :
         environment:
           GIT_COMMIT_MSG: $( git log --format=oneline -n 1 $CIRCLE_SHA1 )
+    - if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then find $SCRATCH -name "*.nii.gz" -type f  | sed s+$SCRATCH+/scratch+ | sort | xargs -n1 $HASHCMD >> $SCRATCH/nii_outputs.txt && diff $HOME/$CIRCLE_PROJECT_REPONAME/tests/nii_outputs.txt $SCRATCH/nii_outputs.txt ; fi :
+        timeout: 3200
+        environment:
+          GIT_COMMIT_MSG: $( git log --format=oneline -n 1 $CIRCLE_SHA1 )
+          HASHCMD: docker run -i -v $SCRATCH:/scratch --entrypoint="/usr/local/miniconda/bin/nib-hash" poldracklab/mriqc:latest
 general:
   artifacts:
     - "~/scratch"

--- a/circle.yml
+++ b/circle.yml
@@ -19,20 +19,26 @@ dependencies:
     # Create scratch folder and force group permissions
     - mkdir -p $SCRATCH && sudo setfacl -d -m group:ubuntu:rwx $SCRATCH && sudo setfacl -m group:ubuntu:rwx $SCRATCH
     - if [[ ! -d ~/data/${TEST_DATA_NAME} ]]; then wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q -O ${TEST_DATA_NAME}.tar.gz "${TEST_DATA_URL}" && tar xzf ${TEST_DATA_NAME}.tar.gz -C ~/data/; fi
+    - if [ "$CIRCLE_TAG" != "" ]; then sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" mriqc/info.py ; fi
   override:
-    - sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" mriqc/info.py
     - docker pull poldracklab/mriqc:circleci || true
-    - e=1 && for i in {1..5}; do docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15; done && [ "$e" -eq "0" ]
+    - |
+      e=1
+      for i in {1..5}; do
+          docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
+      done && [ "$e" -eq "0" ]
   post:
-    - if [[ -n "$DOCKER_PASS" ]]; then docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS && docker push poldracklab/mriqc:circleci; fi :
+    - ? |
+        if [[ -n "$DOCKER_PASS" ]]; then
+          docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS && \
+          docker push poldracklab/mriqc:circleci
+        fi
+      :
         timeout: 21600
 test:
   override:
-    - ? |
-        if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then
-            docker run -i -v /etc/localtime:/etc/localtime:ro -v ${CIRCLE_TEST_REPORTS}:/scratch --entrypoint="py.test"  poldracklab/mriqc:latest --ignore=src/ --junitxml=/scratch/tests.xml /root/src/mriqc;
-        fi
-      :
+    # Test mriqcp
+    - if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then docker run -i -v /etc/localtime:/etc/localtime:ro -v ${CIRCLE_TEST_REPORTS}:/scratch --entrypoint="py.test"  poldracklab/mriqc:latest --ignore=src/ --junitxml=/scratch/tests.xml /root/src/mriqc; fi :
         timeout: 2600
         environment:
           GIT_COMMIT_MSG: $( git log --format=oneline -n 1 $CIRCLE_SHA1 )
@@ -55,11 +61,6 @@ test:
     - if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then docker run -i -v /etc/localtime:/etc/localtime:ro -v $SCRATCH:/scratch -w /scratch --entrypoint="dfcheck" poldracklab/mriqc:latest -i /scratch/out/bold.csv -r /root/src/mriqc/mriqc/data/testdata/bold.csv; fi :
         environment:
           GIT_COMMIT_MSG: $( git log --format=oneline -n 1 $CIRCLE_SHA1 )
-    - if [ "$(grep -qiP 'build[ _]?only' <<< "$GIT_COMMIT_MSG"; echo $? )" == "1" ]; then find $SCRATCH -name "*.nii.gz" -type f  | sed s+$SCRATCH+/scratch+ | sort | xargs -n1 $HASHCMD >> $SCRATCH/nii_outputs.txt && diff $HOME/$CIRCLE_PROJECT_REPONAME/tests/nii_outputs.txt $SCRATCH/nii_outputs.txt ; fi :
-        timeout: 3200
-        environment:
-          GIT_COMMIT_MSG: $( git log --format=oneline -n 1 $CIRCLE_SHA1 )
-          HASHCMD: docker run -i -v $SCRATCH:/scratch --entrypoint="/usr/local/miniconda/bin/nib-hash" poldracklab/mriqc:latest
 general:
   artifacts:
     - "~/scratch"

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,6 @@ dependencies:
     - if [ "$CIRCLE_TAG" != "" ]; then sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" mriqc/info.py ; fi
     - docker load --input $HOME/docker/cache.tar || true
   override:
-    - docker pull poldracklab/mriqc:circleci || true
     - ? |
         e=1
         for i in {1..5}; do
@@ -33,14 +32,6 @@ dependencies:
         timeout: 3200
     - docker save -o $HOME/docker/cache.tar ubuntu:xenial-20161213 poldracklab/mriqc:circleci :
         timeout: 3200
-  post:
-    - ? |
-        if [[ -n "$DOCKER_PASS" ]]; then
-          docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS && \
-          docker push poldracklab/mriqc:circleci
-        fi
-      :
-        timeout: 21600
 test:
   override:
     # Test mriqcp

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
 machine:
+  pre:
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
+    - sudo chmod 0755 /usr/bin/docker
   environment:
     SCRATCH: "$HOME/scratch"
     TEST_DATA_NAME: "circle-tests"
@@ -18,6 +21,7 @@ dependencies:
     - mkdir -p $SCRATCH && sudo setfacl -d -m group:ubuntu:rwx $SCRATCH && sudo setfacl -m group:ubuntu:rwx $SCRATCH
     - if [[ ! -d ~/data/${TEST_DATA_NAME} ]]; then wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q -O ${TEST_DATA_NAME}.tar.gz "${TEST_DATA_URL}" && tar xzf ${TEST_DATA_NAME}.tar.gz -C ~/data/; fi
     - if [ "$CIRCLE_TAG" != "" ]; then sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" mriqc/info.py ; fi
+    - docker load --input $HOME/docker/cache.tar || true
   override:
     - docker pull poldracklab/mriqc:circleci || true
     - |
@@ -25,6 +29,8 @@ dependencies:
       for i in {1..5}; do
           docker build --rm=false -t poldracklab/mriqc:latest -t poldracklab/mriqc:circleci --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION="${CIRCLE_TAG:-99.99.99}" . && e=0 && break || sleep 15
       done && [ "$e" -eq "0" ]
+    - docker save -o $HOME/docker/cache.tar ubuntu:xenial-20161213 poldracklab/mriqc:circleci :
+        timeout: 3200
   post:
     - ? |
         if [[ -n "$DOCKER_PASS" ]]; then


### PR DESCRIPTION
~~~Creates a new tag (poldracklab/mriqc:circleci) that gets updated after every successful push. This should keep all the changes for following builds.~~~
~~~An original idea stolen from @effigies~~~

After testing, the best option is using the `docker save/load` trick.