### PR TITLE
[ENH] Change default --ants-nthreads

### DIFF
--- a/.circleci/participant.sh
+++ b/.circleci/participant.sh
@@ -37,7 +37,7 @@ DOCKER_RUN="docker run -i -v $HOME/data:/data:ro \
 
 case $CIRCLE_NODE_INDEX in
     0)
-        ${DOCKER_RUN} -m T1w --n_procs 2 --ants-nthreads 1
+        ${DOCKER_RUN} -m T1w --n_procs 2
         ;;
     1)
         # Run tests in bold build which is shorter
@@ -46,7 +46,7 @@ case $CIRCLE_NODE_INDEX in
                    --ignore=src/ \
                    --junitxml=/scratch/tests.xml \
                    /root/src/mriqc && \
-        ${DOCKER_RUN} -m bold --testing --n_procs 2 --ants-nthreads 1 --ica
+        ${DOCKER_RUN} -m bold --testing --n_procs 2 --ica
         exit $(( $? + $exit_docs ))
         ;;
 esac

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,10 @@
     * Revised labels file for ds030.
     * Add IQMs for ABIDE and DS030 calculated with MRIQC 0.9.6.
   * ANNOUNCEMENT: Dropped support for Python<=3.4
+  * WARNING (#596): 
+    We have changed the default number of threads for ANTs. Using parallelism with ANTs
+    causes numerical instability on the calculated measures. The most sensitive metrics to this
+    problem are the kurtosis calculations on the intensities of regions and qi_2.
 
 0.9.6
 =====

--- a/mriqc/bin/mriqc_run.py
+++ b/mriqc/bin/mriqc_run.py
@@ -125,7 +125,7 @@ def get_parser():
     # ANTs options
     g_ants = parser.add_argument_group('Specific settings for ANTs')
     g_ants.add_argument(
-        '--ants-nthreads', action='store', type=int, default=0,
+        '--ants-nthreads', action='store', type=int, default=1,
         help='number of threads that will be set in ANTs processes')
     g_ants.add_argument('--ants-settings', action='store',
                         help='path to JSON file with settings for ANTS')


### PR DESCRIPTION
Using parallelism with ANTs causes numerical instability on the calculated measures. The most sensitive metrics to this problem are the kurtosis calculations on the intensities of regions and qi_2.