### PR TITLE
RF: Resume external nipype dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'niworkflows.nipype.sphinxext.plot_workflow',
+    'nipype.sphinxext.plot_workflow',
     'sphinxarg.ext',  # argparse extension
     # 'sphinx.ext.autosectionlabel',
 ]
@@ -64,7 +64,7 @@ if pver.parse(sphinxversion) >= pver.parse('1.7.0'):
         'nipype',
         'niworkflows.interfaces.registration',
         'niworkflows.interfaces',
-        'niworkflows.nipype',
+        'nipype',
         'niworkflows',
         'nilearn',
         'seaborn',

--- a/mriqc/__about__.py
+++ b/mriqc/__about__.py
@@ -56,7 +56,7 @@ CLASSIFIERS = [
 SETUP_REQUIRES = []
 
 REQUIRES = [
-    'niworkflows>=0.3.7',
+    'niworkflows>=0.4.0',
     'pybids>=0.5.0',
     'numpy>=1.12.0',
     'scikit-learn>=0.19.0',
@@ -81,8 +81,6 @@ REQUIRES = [
 ]
 
 LINKS_REQUIRES = [
-    "git+https://github.com/effigies/niworkflows.git@"
-    "4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows",
 ]
 
 

--- a/mriqc/__about__.py
+++ b/mriqc/__about__.py
@@ -81,6 +81,8 @@ REQUIRES = [
 ]
 
 LINKS_REQUIRES = [
+    "git+https://github.com/effigies/niworkflows.git@"
+    "4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows",
 ]
 
 

--- a/mriqc/bin/mriqc_run.py
+++ b/mriqc/bin/mriqc_run.py
@@ -155,8 +155,8 @@ def get_parser():
 
 def main():
     """Entry point"""
-    from niworkflows.nipype import config as ncfg, logging as nlog
-    from niworkflows.nipype.pipeline.engine import Workflow
+    from nipype import config as ncfg, logging as nlog
+    from nipype.pipeline.engine import Workflow
 
     from .. import logging
     from ..utils.bids import collect_bids_data

--- a/mriqc/interfaces/anatomical.py
+++ b/mriqc/interfaces/anatomical.py
@@ -15,9 +15,9 @@ from math import sqrt
 import scipy.ndimage as nd
 from builtins import zip
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
     traits, TraitedSpec, File, isdefined, InputMultiPath, BaseInterfaceInputSpec,
     SimpleInterface
 )

--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -12,8 +12,8 @@ import re
 import simplejson as json
 from io import open
 from builtins import bytes, str
-from niworkflows.nipype import logging
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.interfaces.base import (
     traits, isdefined, TraitedSpec, DynamicTraitedSpec, BaseInterfaceInputSpec,
     File, Undefined, Str, SimpleInterface
 )

--- a/mriqc/interfaces/common.py
+++ b/mriqc/interfaces/common.py
@@ -10,12 +10,12 @@ from pkg_resources import resource_filename as pkgrf
 import numpy as np
 import nibabel as nb
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec, File, isdefined,
     SimpleInterface
 )
-from niworkflows.nipype.interfaces.ants import ApplyTransforms
+from nipype.interfaces.ants import ApplyTransforms
 
 
 IFLOGGER = logging.getLogger('interface')

--- a/mriqc/interfaces/functional.py
+++ b/mriqc/interfaces/functional.py
@@ -10,11 +10,11 @@ import nibabel as nb
 from nilearn.signal import clean
 from builtins import zip
 
-from niworkflows.nipype.interfaces.base import (
+from nipype.interfaces.base import (
     traits, TraitedSpec, File, isdefined, BaseInterfaceInputSpec,
     SimpleInterface
 )
-from niworkflows.nipype import logging
+from nipype import logging
 
 from ..utils.misc import _flatten_dict
 from ..qc.anatomical import snr, fber, efc, summary_stats

--- a/mriqc/interfaces/transitional.py
+++ b/mriqc/interfaces/transitional.py
@@ -4,7 +4,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from niworkflows.nipype.interfaces.base import (
+from nipype.interfaces.base import (
     File, traits, CommandLine, TraitedSpec, CommandLineInputSpec
 )
 

--- a/mriqc/interfaces/viz.py
+++ b/mriqc/interfaces/viz.py
@@ -12,7 +12,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 import os.path as op
 import numpy as np
-from niworkflows.nipype.interfaces.base import (
+from nipype.interfaces.base import (
     traits, TraitedSpec, File, BaseInterfaceInputSpec, isdefined,
     SimpleInterface)
 

--- a/mriqc/interfaces/webapi.py
+++ b/mriqc/interfaces/webapi.py
@@ -4,8 +4,8 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.interfaces.base import (
     Bunch, traits, isdefined, TraitedSpec, BaseInterfaceInputSpec, File, Str,
     SimpleInterface
 )

--- a/mriqc/workflows/anatomical.py
+++ b/mriqc/workflows/anatomical.py
@@ -42,10 +42,10 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 from builtins import zip, range
 import os.path as op
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import io as nio
-from niworkflows.nipype.interfaces import utility as niu
-from niworkflows.nipype.interfaces import fsl, ants
+from nipype.pipeline import engine as pe
+from nipype.interfaces import io as nio
+from nipype.interfaces import utility as niu
+from nipype.interfaces import fsl, ants
 from niworkflows.data import get_mni_icbm152_nlin_asym_09c
 from niworkflows.anat.skullstrip import afni_wf as skullstrip_wf
 from niworkflows.interfaces.registration import RobustMNINormalizationRPT as RobustMNINormalization
@@ -452,7 +452,7 @@ def headmsk_wf(name='HeadMaskWorkflow', use_bet=True):
         ])
 
     else:
-        from niworkflows.nipype.interfaces.dipy import Denoise
+        from nipype.interfaces.dipy import Denoise
         enhance = pe.Node(niu.Function(
             input_names=['in_file'], output_names=['out_file'], function=_enhance), name='Enhance')
         estsnr = pe.Node(niu.Function(
@@ -528,7 +528,7 @@ def airmsk_wf(name='AirMaskWorkflow'):
 
 def _add_provenance(in_file, settings, air_msk, rot_msk):
     from mriqc import __version__ as version
-    from niworkflows.nipype.utils.filemanip import hash_infile
+    from nipype.utils.filemanip import hash_infile
     import nibabel as nb
     import numpy as np
 

--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -32,11 +32,11 @@ This workflow is orchestrated by :py:func:`fmri_qc_workflow`.
 from __future__ import print_function, division, absolute_import, unicode_literals
 import os.path as op
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.algorithms import confounds as nac
-from niworkflows.nipype.interfaces import io as nio
-from niworkflows.nipype.interfaces import utility as niu
-from niworkflows.nipype.interfaces import afni, ants, fsl
+from nipype.pipeline import engine as pe
+from nipype.algorithms import confounds as nac
+from nipype.interfaces import io as nio
+from nipype.interfaces import utility as niu
+from nipype.interfaces import afni, ants, fsl
 
 from niworkflows.interfaces import segmentation as nws
 from niworkflows.interfaces import registration as nwr
@@ -805,7 +805,7 @@ def spikes_mask(in_file, in_mask=None, out_file=None):
 
 def _add_provenance(in_file, settings):
     from mriqc import __version__ as version
-    from niworkflows.nipype.utils.filemanip import hash_infile
+    from nipype.utils.filemanip import hash_infile
     out_prov = {
         'md5sum': hash_infile(in_file),
         'version': version,

--- a/mriqc/workflows/utils.py
+++ b/mriqc/workflows/utils.py
@@ -23,7 +23,7 @@ def _tofloat(inlist):
 def fmri_getidx(in_file, start_idx, stop_idx):
     """Heuristics to set the start and stop indices of fMRI series"""
     from nibabel import load
-    from niworkflows.nipype.interfaces.base import isdefined
+    from nipype.interfaces.base import isdefined
     nvols = load(in_file).shape[3]
     max_idx = nvols - 1
 
@@ -166,7 +166,7 @@ def slice_wise_fft(in_file, ftmask=None, spike_thres=3., out_prefix=None):
 
 
 def get_fwhmx():
-    from niworkflows.nipype.interfaces.afni import Info, FWHMx
+    from nipype.interfaces.afni import Info, FWHMx
     fwhm_args = {"combine": True,
                  "detrend": True}
     afni_version = StrictVersion('%s.%s.%s' % Info.version())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.12.0
 scikit-learn>=0.19
-niworkflows>=0.3.7
+git+https://github.com/effigies/niworkflows.git@4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.12.0
 scikit-learn>=0.19
-git+https://github.com/effigies/niworkflows.git@4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows
+niworkflows>=0.4.0


### PR DESCRIPTION
Purges `niworkflows.nipype` in favor of `nipype`.

Pins poldracklab/niworkflows#241.

----

#### Original text:

This is just to validate poldracklab/niworkflows#238. Should be a functionally inert refactor, so can wait for the next niworkflows release to actually update the pin.