### PR TITLE
[FIX] Calculate relative path with sessions

### DIFF
--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -58,8 +58,8 @@ class ReadSidecarJSON(SimpleInterface):
         # Crawl back to the BIDS root
         path = Path(self.inputs.in_file)
         for i in range(1, 4):
-            bids_root = path.parents[i]
-            if str(bids_root).startswith('sub-'):
+            if str(path.parents[i].name).startswith('sub-'):
+                bids_root = path.parents[i + 1]
                 break
 
         self._results['relative_path'] = str(path.relative_to(bids_root))

--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -57,7 +57,7 @@ class ReadSidecarJSON(SimpleInterface):
 
         # Crawl back to the BIDS root
         path = Path(self.inputs.in_file)
-        for i in range(1, 3):
+        for i in range(1, 4):
             bids_root = path.parents[i]
             if str(bids_root).startswith('sub-'):
                 break


### PR DESCRIPTION
Fixes the path relative to the BIDS root calculated for each file, that will be used as pattern for writing out the results.

It worked for single-session datasets, but was broken for multi-session datasets.