### PR TITLE
Fix permissions in the Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,7 @@ COPY . /usr/local/src/mriqc
 ARG VERSION
 RUN echo "${VERSION}" > mriqc/VERSION && \
     pip install .[all] && \
+    find /usr/local/miniconda/lib/python*/site-packages/mriqc -type f -exec chmod a+r {} \; && \
     rm -rf ~/.cache/pip
 
 # Run mriqc by default


### PR DESCRIPTION
Fixes the permissions for the "mriqc" python package in the Docker image so that any user can run it.
Currently, because mriqc is installed after the permissions for the python packages were changed in line 111:https://github.com/poldracklab/mriqc/blob/471d7bb8a6f1611bec813fd62175ea74494552af/Dockerfile#L111,
the package "mriqc" is not world readable, so the permissions for the package "mriqc" have to be reset again.