### PR TITLE
[FIX] Niworkflows pin <0.5

### DIFF
--- a/mriqc/__about__.py
+++ b/mriqc/__about__.py
@@ -57,7 +57,7 @@ SETUP_REQUIRES = []
 
 REQUIRES = [
     'nipype>=1.1.1',
-    'niworkflows>=0.4.2',
+    'niworkflows>=0.4.2,<0.5',
     'pybids>=0.6.4',
     'numpy>=1.12.0',
     'pandas>=0.21.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-niworkflows>=0.4.2
+niworkflows>=0.4.2,<0.5


### PR DESCRIPTION
Builds are failing in CircleCI because the niworkflows>=0.5 breaks
backwards compatibility.