### PR TITLE
[FIX] Catch uncaught exception in WebAPI upload.

### DIFF
--- a/docs/source/reports/group.rst
+++ b/docs/source/reports/group.rst
@@ -2,7 +2,7 @@
 .. _reports-group:
 
 Group reports
-=============
+-------------
 
 Once a sample has been processed with the appropriate
 :ref:`workflow <workflows>`, all the :abbr:`IQMs (image quality metrics)`

--- a/docs/source/reports/group.rst
+++ b/docs/source/reports/group.rst
@@ -2,7 +2,7 @@
 .. _reports-group:
 
 Group reports
--------------
+=============
 
 Once a sample has been processed with the appropriate
 :ref:`workflow <workflows>`, all the :abbr:`IQMs (image quality metrics)`

--- a/mriqc/bin/mriqc_run.py
+++ b/mriqc/bin/mriqc_run.py
@@ -37,9 +37,7 @@ def get_parser():
     from .. import DEFAULTS, __description__
 
     parser = ArgumentParser(
-        description="""\
-MRIQC: MRI Quality Control
---------------------------
+        description="""MRIQC: MRI Quality Control\n--------------------------\
 %s
 %s""" % (__description__, DSA_MESSAGE),
         formatter_class=RawTextHelpFormatter)

--- a/mriqc/interfaces/webapi.py
+++ b/mriqc/interfaces/webapi.py
@@ -150,7 +150,7 @@ class UploadIQMs(SimpleInterface):
 
         try:
             self._results['api_id'] = response.json()['_id']
-        except (ValueError, KeyError, AttributeError):
+        except (AttributeError, KeyError, ValueError):
             # response did not give us an ID
             errmsg = ('QC metrics upload failed to create an ID for the record '
                       'uplOADED. rEsponse from server follows: {}'.format(response.text))

--- a/mriqc/interfaces/webapi.py
+++ b/mriqc/interfaces/webapi.py
@@ -150,7 +150,7 @@ class UploadIQMs(SimpleInterface):
 
         try:
             self._results['api_id'] = response.json()['_id']
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, AttributeError):
             # response did not give us an ID
             errmsg = ('QC metrics upload failed to create an ID for the record '
                       'uplOADED. rEsponse from server follows: {}'.format(response.text))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 niworkflows>=0.4.2,<0.5
+pybids<=0.6.5


### PR DESCRIPTION
As described in #750 
webapi upload function will return bunch object instead of response in certain circumstances causing an AttributeError to be thrown. We should catch this.
