### PR TITLE
CI: Use recent Python image to build packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,7 +515,7 @@ jobs:
       - run:
           name: Start virtual environment
           command: |
-            sudo python -m pip install "setuptools>=30.3.0" "pip>=10.0.1" twine docutils numpy nipy
+            sudo python -m pip install "setuptools>=30.3.0" "pip>=10.0.1" twine docutils
             python -m venv /tmp/venv
             source /tmp/venv/bin/activate
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,50 +507,54 @@ jobs:
             fi
 
   test_package:
-    machine:
-      image: circleci/classic:201711-01
+    docker:
+      - image: circleci/python:3.7.4
     working_directory: /tmp/src/mriqc
     steps:
       - checkout
-      - run: pyenv local 3.5.2
       - run:
-          name: Install build depends
-          command: python3 -m pip install "setuptools>=30.3.0" "pip>=10.0.1" twine docutils
+          name: Start virtual environment
+          command: |
+            sudo python -m pip install "setuptools>=30.3.0" "pip>=10.0.1" twine docutils numpy nipy
+            python -m venv /tmp/venv
+            source /tmp/venv/bin/activate
       - run:
           name: Build and check
           command: |
-            python3 setup.py sdist
-            python3 -m twine check dist/*
+            python setup.py sdist
+            python -m twine check dist/*
       - run:
           name: Validate version
           command: |
             if [[ "${CIRCLE_TAG}" != "" ]]; then
               echo "${CIRCLE_TAG}" > mriqc/VERSION
             fi
-            THISVERSION=$( python3 -c "from versioneer import get_version; print(get_version())" )
-            python3 -m pip install dist/*.tar.gz
+            THISVERSION=$( python -c "from versioneer import get_version; print(get_version())" )
+            python -m pip install --user dist/*.tar.gz
             mkdir empty
             cd empty
-            INSTALLED=$( python3 -c 'import mriqc; print(mriqc.__version__)' )
+            INSTALLED=$( python -c 'import mriqc; print(mriqc.__version__)' )
             test "${CIRCLE_TAG:-$THISVERSION}" == "$INSTALLED"
 
   deploy_pypi:
-    machine:
-      image: circleci/classic:201711-01
+    docker:
+      - image: circleci/python:3.7.4
     working_directory: /tmp/src/mriqc
     steps:
       - checkout
-      - run: pyenv local 3.5.2
       - run:
-          name: Install build depends
-          command: python3 -m pip install "setuptools>=30.3.0" "pip>=10.0.1" twine docutils
+          name: Start virtual environment
+          command: |
+            sudo python -m pip install "setuptools>=30.3.0" "pip>=10.0.1" twine docutils
+            python -m venv /tmp/venv
+            source /tmp/venv/bin/activate
       - run:
           name: Deploy to PyPi
           command: |
             echo "${CIRCLE_TAG}" > mriqc/VERSION
-            python3 setup.py sdist
-            python3 -m twine check dist/*
-            python3 -m twine upload dist/*
+            python setup.py sdist
+            python -m twine check dist/*
+            python -m twine upload dist/*
 
   deploy_docker:
     machine:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ if pver.parse(sphinxversion) >= pver.parse('1.7.0'):
         'numpy',
         'scipy',
         'sklearn',
-        'statsmodel',
+        'statsmodels',
         'nipype',
         'niworkflows.interfaces.registration',
         'niworkflows.interfaces',

--- a/mriqc/qc/anatomical.py
+++ b/mriqc/qc/anatomical.py
@@ -194,9 +194,6 @@ import numpy as np
 import scipy.ndimage as nd
 from scipy.stats import kurtosis  # pylint: disable=E0611
 
-from io import open  # pylint: disable=W0622
-from builtins import zip, range  # pylint: disable=W0622
-from six import string_types
 
 DIETRICH_FACTOR = 1.0 / sqrt(2 / (4 - pi))
 FSL_FAST_LABELS = {'csf': 1, 'gm': 2, 'wm': 3, 'bg': 0}
@@ -621,7 +618,7 @@ def _prepare_mask(mask, label, erode=True):
     fgmask = mask.copy()
 
     if np.issubdtype(fgmask.dtype, np.integer):
-        if isinstance(label, string_types):
+        if isinstance(label, (str, bytes)):
             label = FSL_FAST_LABELS[label]
 
         fgmask[fgmask != label] = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,18 +26,14 @@ install_requires =
     matplotlib
     nibabel >= 2.2.1
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
-    nipy
     nipype >= 1.1.1
-    nitime
     niworkflows ~= 0.10.3rc1
     numpy
     pandas>=0.21.0
     pybids ~= 0.9.2
-    scikit-image
     scikit-learn>=0.19.0
     scipy
     seaborn
-    six
     statsmodels
     svgutils
     templateflow ~= 0.4.1
@@ -86,8 +82,14 @@ docs =
 notebook =
     ipython
     jupyter
+    nipy
 notebooks =
     %(notebook)s
+
+other =
+    scikit-image
+others =
+    %(other)s
 
 test =
     coverage


### PR DESCRIPTION
Similarly to poldracklab/fmriprep#1790, we are changing to the Python
3.7+ docker image to test and deploy the Pypi package since twine has
stopped support for python <3.6 since their latest relase 2.0.