### PR TITLE
MAINT: Clear the clutter of warnings

### DIFF
--- a/mriqc/_warnings.py
+++ b/mriqc/_warnings.py
@@ -1,0 +1,36 @@
+"""Manipulate Python warnings."""
+import warnings
+import logging
+
+_wlog = logging.getLogger("py.warnings")
+_wlog.addHandler(logging.NullHandler())
+
+
+def _warn(message, category=None, stacklevel=1, source=None):
+    """Redefine the warning function."""
+    if category is not None:
+        category = type(category).__name__
+        category = category.replace("type", "WARNING")
+
+    logging.getLogger("py.warnings").warning(
+        f"{category or 'WARNING'}: {message}"
+    )
+
+
+def _showwarning(message, category, filename, lineno, file=None, line=None):
+    _warn(message, category=category)
+
+
+warnings.warn = _warn
+warnings.showwarning = _showwarning
+
+# warnings.filterwarnings("ignore", category=FutureWarning)
+# warnings.filterwarnings("ignore", category=DeprecationWarning)
+# warnings.filterwarnings("ignore", category=ResourceWarning)
+# # cmp is not used by mriqc, so ignore nipype-generated warnings
+# warnings.filterwarnings("ignore", "cmp not installed")
+# warnings.filterwarnings(
+#     "ignore", "This has not been fully tested. Please report any failures."
+# )
+# warnings.filterwarnings("ignore", "sklearn.externals.joblib is deprecated in 0.21")
+# warnings.filterwarnings("ignore", "can't resolve package from __spec__ or __package__")

--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -67,18 +67,7 @@ The :py:mod:`config` is responsible for other conveniency actions.
     :py:class:`~bids.layout.BIDSLayout`, etc.)
 
 """
-import warnings
-
-warnings.filterwarnings("ignore", category=FutureWarning)
-warnings.filterwarnings("ignore", category=DeprecationWarning)
-warnings.filterwarnings("ignore", category=ResourceWarning)
-# cmp is not used by mriqc, so ignore nipype-generated warnings
-warnings.filterwarnings("ignore", "cmp not installed")
-warnings.filterwarnings(
-    "ignore", "This has not been fully tested. Please report any failures."
-)
-warnings.filterwarnings("ignore", "sklearn.externals.joblib is deprecated in 0.21")
-warnings.filterwarnings("ignore", "can't resolve package from __spec__ or __package__")
+from ._warnings import logging
 
 try:
     from multiprocessing import set_start_method
@@ -90,24 +79,22 @@ finally:
     # ignoring the most annoying warnings
     import os
     import sys
-    import logging
 
     from uuid import uuid4
     from pathlib import Path
     from time import strftime
-    from niworkflows.utils.spaces import SpatialReferences as _SRs, Reference as _Ref
     from nipype import __version__ as _nipype_ver
     from templateflow import __version__ as _tf_ver
     from . import __version__
 
-
-def redirect_warnings(message, category, filename, lineno, file=None, line=None):
-    """Redirect other warnings."""
-    logger = logging.getLogger()
-    logger.debug("Captured warning (%s): %s", category, message)
-
-
-warnings.showwarning = redirect_warnings
+sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
+# Disable all warnings in main and children processes only on production versions
+if not any((
+    "+" in __version__,
+    __version__.endswith(".dirty"),
+    os.getenv("MRIQC_DEV", "0").lower() in ("1", "on", "true", "y", "yes")
+)):
+    os.environ["PYTHONWARNINGS"] = "ignore"
 
 logging.addLevelName(25, "IMPORTANT")  # Add a new level between INFO and WARNING
 logging.addLevelName(15, "VERBOSE")  # Add a new level between INFO and DEBUG
@@ -206,10 +193,6 @@ class _Config:
                 continue
             if k in cls._paths:
                 v = str(v)
-            if isinstance(v, _SRs):
-                v = " ".join([str(s) for s in v.references]) or None
-            if isinstance(v, _Ref):
-                v = str(v) or None
             out[k] = v
         return out
 

--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -87,7 +87,8 @@ finally:
     from templateflow import __version__ as _tf_ver
     from . import __version__
 
-sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
+if not hasattr(sys, "_is_pytest_session"):
+    sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
 # Disable all warnings in main and children processes only on production versions
 if not any((
     "+" in __version__,

--- a/mriqc/workflows/anatomical.py
+++ b/mriqc/workflows/anatomical.py
@@ -32,16 +32,13 @@ For the skull-stripping, we use ``afni_wf`` from ``niworkflows.anat.skullstrip``
 
 
 """
+from .. import config
 from nipype.pipeline import engine as pe
 from nipype.interfaces import io as nio
 from nipype.interfaces import utility as niu
 from nipype.interfaces import fsl, ants
 from templateflow.api import get as get_template
-from niworkflows.interfaces.bids import ReadSidecarJSON
-from niworkflows.interfaces.registration import RobustMNINormalizationRPT as RobustMNINormalization
-from niworkflows.anat.skullstrip import afni_wf as skullstrip_wf
 
-from .. import config
 from ..interfaces import (StructuralQC, ArtifactMask, ConformImage,
                           ComputeQI2, IQMFileSink, RotationMask)
 from ..interfaces.reports import AddProvenance
@@ -62,6 +59,8 @@ def anat_qc_workflow(name='anatMRIQC'):
             wf = anat_qc_workflow()
 
     """
+    from niworkflows.anat.skullstrip import afni_wf as skullstrip_wf
+
     dataset = config.workflow.inputs.get("T1w", []) \
         + config.workflow.inputs.get("T2w", [])
 
@@ -160,6 +159,10 @@ Building anatomical MRIQC workflow for files: {', '.join(dataset)}.""")
 
 def spatial_normalization(name='SpatialNormalization', resolution=2):
     """Create a simplied workflow to perform fast spatial normalization."""
+    from niworkflows.interfaces.registration import (
+        RobustMNINormalizationRPT as RobustMNINormalization
+    )
+
     # Have the template id handy
     tpl_id = config.workflow.template_id
 
@@ -207,6 +210,7 @@ def compute_iqms(name='ComputeIQMs'):
             wf = compute_iqms()
 
     """
+    from niworkflows.interfaces.bids import ReadSidecarJSON
     from .utils import _tofloat
     from ..interfaces.anatomical import Harmonize
 


### PR DESCRIPTION
The warnings are handled in two ways:

  * If this is a release, ignore all warnings (MRIQC does not use Python's warnings module, but logging instead).
  * If development, warnings.showwarning and warnings.warn are monkeypatched to redirect to the ``'py.warnings'`` logger. The logger writes to /dev/null, but that can we change for debugging purposes.

Related: poldracklab/fmriprep#1981