### PR TITLE
FIX: honor OMP_NUM_THREADS environment variable

### DIFF
--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -246,7 +246,7 @@ class nipype(_Config):
     """Estimation in GB of the RAM this workflow can allocate at any given time."""
     nprocs = os.cpu_count()
     """Number of processes (compute tasks) that can be run in parallel (multiprocessing only)."""
-    omp_nthreads = os.cpu_count()
+    omp_nthreads = int(os.getenv('OMP_NUM_THREADS', os.cpu_count()))
     """Number of CPUs a single process can access for multithreaded execution."""
     plugin = "MultiProc"
     """NiPype's execution plugin."""


### PR DESCRIPTION
We just hit #844 with mriqc 0.15.2.

Looking at https://github.com/poldracklab/mriqc/blob/master/mriqc/cli/parser.py#L378 we thought we could work around that by setting `OMP_NUM_THREADS` to 1 while still using values other than 1 for `--nprocs`. Unfortunately that didn't work because `config.nipype.omp_nthreads` is always [set](https://github.com/poldracklab/mriqc/blob/master/mriqc/config.py#L249) to `os.cpu_count()`.

This PR checks if the OpenMP environment variable exists and defaults back to `os.cpu_count()` - which is a confusing choice anyway, because it will always trigger the config warning if someone uses `--nprocs` other than 1 or `os.cpu_count()`, right?