### PR TITLE
Change depricated 'normed' to 'density' in parameters to hist()

### DIFF
--- a/mriqc/viz/misc.py
+++ b/mriqc/viz/misc.py
@@ -25,7 +25,7 @@ def plot_qi2(x_grid, ref_pdf, fit_pdf, ref_data, cutoff_idx, out_file=None):
         fc="dodgerblue",
         histtype="stepfilled",
         alpha=0.2,
-        normed=True,
+        density=True,
     )
     fit_pdf[fit_pdf > 1.0] = np.nan
     ax.plot(x_grid, fit_pdf, linewidth=2, alpha=0.5, label="chi2", color="darkorange")


### PR DESCRIPTION
Matplotlib has changed the API of the [hist](https://matplotlib.org/3.3.3/api/_as_gen/matplotlib.pyplot.hist.html) function.  The parameter `normed` has been deprecated in favor of `density`.  This appears to cause some problems depending on which version of matplotlib you use, see traceback below.

```
Traceback (most recent call last):
  File "~/.local/lib/python3.6/site-packages/nipype/pipeline/plugins/multiproc.py", line 67, in run_node
    result["result"] = node.run(updatehash=updatehash)
  File "~/.local/lib/python3.6/site-packages/nipype/pipeline/engine/nodes.py", line 516, in run
    result = self._run_interface(execute=True)
  File "~/.local/lib/python3.6/site-packages/nipype/pipeline/engine/nodes.py", line 635, in _run_interface
    return self._run_command(execute)
  File "~/.local/lib/python3.6/site-packages/nipype/pipeline/engine/nodes.py", line 741, in _run_command
    result = self._interface.run(cwd=outdir)
  File "~/.local/lib/python3.6/site-packages/nipype/interfaces/base/core.py", line 434, in run
    runtime = self._run_interface(runtime)
  File "~/.local/lib/python3.6/site-packages/mriqc/interfaces/anatomical.py", line 323, in _run_interface
    qi2, out_file = art_qi2(imdata, airdata)
  File "~/.local/lib/python3.6/site-packages/mriqc/qc/anatomical.py", line 476, in art_qi2
    out_file = plot_qi2(x_grid, kde, chi_pdf, modelx, kdethi)
  File "~/.local/lib/python3.6/site-packages/mriqc/viz/misc.py", line 28, in plot_qi2
    normed=True,
  File "~/.local/lib/python3.6/site-packages/matplotlib/__init__.py", line 1447, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "~/.local/lib/python3.6/site-packages/matplotlib/axes/_axes.py", line 6815, in hist
    p.update(kwargs)
  File "~/.local/lib/python3.6/site-packages/matplotlib/artist.py", line 996, in update
    raise AttributeError(f"{type(self).__name__!r} object "
AttributeError: 'Polygon' object has no property 'normed'
```